### PR TITLE
Fix CreatePostForm nome field

### DIFF
--- a/src/components/CreatePostForm.vue
+++ b/src/components/CreatePostForm.vue
@@ -23,10 +23,10 @@
       </div>
 
       <div class="form-group">
-        <label for="content">Nome:</label>
+        <label for="nome">Nome:</label>
         <textarea
           id="nome"
-         v-model="nome"
+          v-model="nome"
           required
         ></textarea>
       </div>
@@ -43,7 +43,8 @@ export default {
   data() {
     return {
       title: '',
-      content: ''
+      content: '',
+      nome: ''
     }
   },
   methods: {
@@ -51,7 +52,8 @@ export default {
       try {
         const payload = {
           title: this.title,
-          content: this.content
+          content: this.content,
+          nome: this.nome
         }
 
         // Variável de ambiente: process.env.VUE_APP_API_URL
@@ -62,6 +64,7 @@ export default {
         // Limpando campos
         this.title = ''
         this.content = ''
+        this.nome = ''
 
         // Emitindo evento para o componente pai atualizar a lista
         this.$emit('postCreated')


### PR DESCRIPTION
## Summary
- fix name input binding

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68686cf23bac8328aa2f52b3ea8fcef9

## Resumo por Sourcery

Corrige o componente CreatePostForm para lidar corretamente com o novo campo `nome`, vinculando-o no formulário, incluindo-o no payload de envio e limpando-o após o envio.

Correções de bugs:
- Corrige o atributo `for` do label do formulário e a vinculação `v-model` para a textarea `nome`.
- Inicializa a propriedade de dados `nome`, inclui-a no payload enviado para a API e redefine-a após a criação de uma postagem.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the CreatePostForm component to properly handle the new `nome` field by binding it in the form, including it in the submission payload, and clearing it after submission.

Bug Fixes:
- Correct the form label `for` attribute and `v-model` binding for the `nome` textarea.
- Initialize the `nome` data property, include it in the payload sent to the API, and reset it after creating a post.

</details>