### PR TITLE
Fix Vite build error by updating Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:16 as build-stage
+FROM node:20 AS build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:stable-alpine as production-stage
+FROM nginx:stable-alpine AS production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- use a newer Node base image in `Dockerfile`
- make `AS` casing consistent

The updated Dockerfile resolves `crypto.getRandomValues` undefined error when building with Vite.

## Testing
- `npm install`
- `npm run build`
- `docker build .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fb129816c8328b277be9fa9f538fc

## Resumo por Sourcery

Atualiza o Dockerfile para usar uma imagem base Node mais recente e padroniza o uso de maiúsculas e minúsculas na palavra-chave stage

Correções de bugs:
- Resolve o erro `crypto.getRandomValues` indefinido nas compilações Vite, atualizando para o Node 20

Build:
- Atualiza a imagem base do Node 16 para o Node 20 no Dockerfile
- Padroniza o uso de maiúsculas e minúsculas da palavra-chave `AS` nos stages de build

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Dockerfile to use a newer Node base image and standardize stage keyword casing

Bug Fixes:
- Resolve undefined `crypto.getRandomValues` error in Vite builds by upgrading to Node 20

Build:
- Upgrade base image from Node 16 to Node 20 in Dockerfile
- Standardize `AS` keyword casing in build stages

</details>